### PR TITLE
Separate clickable areas in contacts

### DIFF
--- a/src/app/contact-page/contact-page.component.css
+++ b/src/app/contact-page/contact-page.component.css
@@ -19,7 +19,7 @@
     gap: clamp(20px, 9vw, 45px);
 }
 
-.contact-container__element {
+.contact-option {
     display: flex;
     flex-direction: row;
     align-items: center;
@@ -27,10 +27,14 @@
     width: fit-content;
     font-size: clamp(1.8rem, 2.5vw, 3.6rem);
     text-decoration: none;
-    color: black;
 }
 
-.contact-container__element__icon {
+:any-link {
+    color: black;
+    text-decoration: none;
+}
+
+.contact-option__icon {
     width: clamp(70px, 5.5vw, 100px);
     aspect-ratio: 1.0;
 }

--- a/src/app/contact-page/contact-page.component.html
+++ b/src/app/contact-page/contact-page.component.html
@@ -1,16 +1,31 @@
 <main class="contact">
     <h2 class="contact__title">Contact</h2>
     <div class="contact-container">
-        <a class="contact-container__element" href="https://www.linkedin.com/in/pedrophpcosta/" rel="noopener noreferer" target="_blank">
-            <img class="contact-container__element__icon" src="../../assets/linkedin.png" alt="LinkedIn Icon"><p>pedrophpcosta</p>
-        </a>
+        <div class="contact-option">
+            <a href="https://www.linkedin.com/in/pedrophpcosta/" rel="noopener noreferer" target="_blank">
+                <img class="contact-option__icon" src="../../assets/linkedin.png" alt="LinkedIn Icon">
+            </a>
+            <a href="https://www.linkedin.com/in/pedrophpcosta/" rel="noopener noreferer" target="_blank">
+                <p>pedrophpcosta</p>
+            </a>
+        </div>
 
-        <a class="contact-container__element" href="https://github.com/Silmunia" rel="noopener noreferer" target="_blank">
-            <img class="contact-container__element__icon" src="../../assets/github.png" alt="Github Icon"><p>Silmunia</p>
-        </a>
+        <div class="contact-option">
+            <a href="https://github.com/Silmunia" rel="noopener noreferer" target="_blank">
+                <img class="contact-option__icon" src="../../assets/github.png" alt="Github Icon">
+            </a>
+            <a href="https://github.com/Silmunia" rel="noopener noreferer" target="_blank">
+                <p>Silmunia</p>
+            </a>
+        </div>
 
-        <a class="contact-container__element" href="mailto:pedrophpcosta@gmail.com" rel="noopener noreferer" target="_blank">
-            <img class="contact-container__element__icon" src="../../assets/email.png" alt="E-mail Icon"><p>pedrophpcosta&#8203;&#64;gmail.com</p>
-        </a>
+        <div class="contact-option">
+            <a href="mailto:pedrophpcosta@gmail.com" rel="noopener noreferer" target="_blank">
+                <img class="contact-option__icon" src="../../assets/email.png" alt="E-mail Icon">
+            </a>
+            <a href="mailto:pedrophpcosta@gmail.com" rel="noopener noreferer" target="_blank">
+                <p>pedrophpcosta&#8203;&#64;gmail.com</p>
+            </a>
+        </div>
     </div>
 </main>


### PR DESCRIPTION
When the entire contact option's block was clickable, it was hard to just copy the text displayed. Now it should be easier to simply copy instead of having to click the link.